### PR TITLE
修复由于章节标题中的特殊字符导致的 ENOENT 错误

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,12 +41,17 @@ const main = async () => {
     for (let i = 0; i < finishSections.length; i++) {
         const section = finishSections[i];
         const sectionInfo = await getSection(section.id);
-        const sectionPath = `${bookName}/${
-            section.index
-        }.${sectionInfo.title.replaceAll("/", "\\")}.md`;
+
+        // 替换章节标题中的特殊字符
+        const safeTitle = sectionInfo.title.replaceAll("/", "-").replaceAll("：", "-");
+
+        // 使用安全的标题来创建文件路径
+        const sectionPath = `${bookName}/${section.index}.${safeTitle}.md`;
+
         fs.writeFileSync(sectionPath, sectionInfo.content);
         console.log(`第 ${section.index} 章下载完成`);
     }
+
 
     console.log(`小册 ${bookName} 下载完成`);
 };


### PR DESCRIPTION
### 问题描述

在写入章节内容到文件时，如果章节标题包含特殊字符（如斜杠 `/` 和冒号 `：`），会导致 'ENOENT: no such file or directory' 错误。

### 解决方案

本 PR 对章节标题进行了清理：

1. 用破折号 `-` 替换了章节标题中的斜杠 `/` 和冒号 `：`。
2. 更新了文件路径，以使用经过清理的章节标题。

这样做确保了文件路径在不同的文件系统中都是有效的，从而避免了 ENOENT 错误。

### 影响

这个更改将解决由于文件路径无效而导致的 ENOENT 错误，不会影响其他功能。

请考虑合并这个 PR，谢谢！